### PR TITLE
Update bmi.h to pass pointer to struct Bmi

### DIFF
--- a/bmi.h
+++ b/bmi.h
@@ -1,13 +1,9 @@
-/*
-   The Basic Model Interface (BMI) C specification.
-
-   This language specification is derived from the Scientific
-   Interface Definition Language (SIDL) file bmi.sidl located at
-   https://github.com/csdms/bmi.
-*/
-
 #ifndef BMI_H
 #define BMI_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 #define BMI_SUCCESS (0)
 #define BMI_FAILURE (1)
@@ -17,69 +13,75 @@
 #define BMI_MAX_COMPONENT_NAME (2048)
 #define BMI_MAX_VAR_NAME (2048)
 
-typedef struct {
-  void *self;
+
+typedef struct BMI_Model {
+  void *data;
 
   /* Initialize, run, finalize (IRF) */
-  int (*initialize)(void *self, char *config_file);
-  int (*update)(void *self);
-  int (*update_until)(void *self, double then);
-  int (*finalize)(void *self);
+  int (*initialize)(struct BMI_Model *self, const char *config_file);
+  int (*update)(struct BMI_Model *self);
+  int (*update_until)(struct BMI_Model *self, double then);
+  int (*finalize)(struct BMI_Model *self);
 
   /* Exchange items */
-  int (*get_component_name)(void *self, char *name);
-  int (*get_input_item_count)(void *self, int *count);
-  int (*get_output_item_count)(void *self, int *count);
-  int (*get_input_var_names)(void *self, char **names);
-  int (*get_output_var_names)(void *self, char **names);
+  int (*get_component_name)(struct BMI_Model *self, char *name);
+  int (*get_input_item_count)(struct BMI_Model *self, int *count);
+  int (*get_output_item_count)(struct BMI_Model *self, int *count);
+  int (*get_input_var_names)(struct BMI_Model *self, char **names);
+  int (*get_output_var_names)(struct BMI_Model *self, char **names);
 
   /* Variable information */
-  int (*get_var_grid)(void *self, const char *name, int *grid);
-  int (*get_var_type)(void *self, const char *name, char *type);
-  int (*get_var_units)(void *self, const char *name, char *units);
-  int (*get_var_itemsize)(void *self, const char *name, int *size);
-  int (*get_var_nbytes)(void *self, const char *name, int *nbytes);
-  int (*get_var_location)(void *self, const char *name, char *location);
+  int (*get_var_grid)(struct BMI_Model *self, const char *name, int *grid);
+  int (*get_var_type)(struct BMI_Model *self, const char *name, char *type);
+  int (*get_var_units)(struct BMI_Model *self, const char *name, char *units);
+  int (*get_var_itemsize)(struct BMI_Model *self, const char *name, int *size);
+  int (*get_var_nbytes)(struct BMI_Model *self, const char *name, int *nbytes);
+  int (*get_var_location)(struct BMI_Model *self, const char *name, char *location);
 
   /* Time information */
-  int (*get_current_time)(void *self, double *time);
-  int (*get_start_time)(void *self, double *time);
-  int (*get_end_time)(void *self, double *time);
-  int (*get_time_units)(void *self, char *units);
-  int (*get_time_step)(void *self, double *time_step);
+  int (*get_current_time)(struct BMI_Model *self, double *time);
+  int (*get_start_time)(struct BMI_Model *self, double *time);
+  int (*get_end_time)(struct BMI_Model *self, double *time);
+  int (*get_time_units)(struct BMI_Model *self, char *units);
+  int (*get_time_step)(struct BMI_Model *self, double *time_step);
 
   /* Getters */
-  int (*get_value)(void *self, const char *name, void *dest);
-  int (*get_value_ptr)(void *self, const char *name, void **dest_ptr);
-  int (*get_value_at_indices)(void *self, const char *name, void *dest, int *inds, int count);
+  int (*get_value)(struct BMI_Model *self, const char *name, void *dest);
+  int (*get_value_ptr)(struct BMI_Model *self, const char *name, void **dest_ptr);
+  int (*get_value_at_indices)(struct BMI_Model *self, const char *name, void *dest, int *inds, int count);
 
   /* Setters */
-  int (*set_value)(void *self, const char *name, void *src);
-  int (*set_value_at_indices)(void *self, const char *name, int *inds, int count, void *src);
+  int (*set_value)(struct BMI_Model *self, const char *name, void *src);
+  int (*set_value_at_indices)(struct BMI_Model *self, const char *name, int *inds, int count, void *src);
 
   /* Grid information */
-  int (*get_grid_rank)(void *self, int grid, int *rank);
-  int (*get_grid_size)(void *self, int grid, int *size);
-  int (*get_grid_type)(void *self, int grid, char *type);
+  int (*get_grid_rank)(struct BMI_Model *self, int grid, int *rank);
+  int (*get_grid_size)(struct BMI_Model *self, int grid, int *size);
+  int (*get_grid_type)(struct BMI_Model *self, int grid, char *type);
 
   /* Uniform rectilinear */
-  int (*get_grid_shape)(void *self, int grid, int *shape);
-  int (*get_grid_spacing)(void *self, int grid, double *spacing);
-  int (*get_grid_origin)(void *self, int grid, double *origin);
+  int (*get_grid_shape)(struct BMI_Model *self, int grid, int *shape);
+  int (*get_grid_spacing)(struct BMI_Model *self, int grid, double *spacing);
+  int (*get_grid_origin)(struct BMI_Model *self, int grid, double *origin);
 
   /* Non-uniform rectilinear, curvilinear */
-  int (*get_grid_x)(void *self, int grid, double *x);
-  int (*get_grid_y)(void *self, int grid, double *y);
-  int (*get_grid_z)(void *self, int grid, double *z);
+  int (*get_grid_x)(struct BMI_Model *self, int grid, double *x);
+  int (*get_grid_y)(struct BMI_Model *self, int grid, double *y);
+  int (*get_grid_z)(struct BMI_Model *self, int grid, double *z);
 
   /* Unstructured */
-  int (*get_grid_node_count)(void *self, int grid, int *count);
-  int (*get_grid_edge_count)(void *self, int grid, int *count);
-  int (*get_grid_face_count)(void *self, int grid, int *count);
-  int (*get_grid_edge_nodes)(void *self, int grid, int *edge_nodes);
-  int (*get_grid_face_edges)(void *self, int grid, int *face_edges);
-  int (*get_grid_face_nodes)(void *self, int grid, int *face_nodes);
-  int (*get_grid_nodes_per_face)(void *self, int grid, int *nodes_per_face);
-} Bmi;
+  int (*get_grid_node_count)(struct BMI_Model *self, int grid, int *count);
+  int (*get_grid_edge_count)(struct BMI_Model *self, int grid, int *count);
+  int (*get_grid_face_count)(struct BMI_Model *self, int grid, int *count);
+  int (*get_grid_edge_nodes)(struct BMI_Model *self, int grid, int *edge_nodes);
+  int (*get_grid_face_edges)(struct BMI_Model *self, int grid, int *face_edges);
+  int (*get_grid_face_nodes)(struct BMI_Model *self, int grid, int *face_nodes);
+  int (*get_grid_nodes_per_face)(struct BMI_Model *self, int grid, int *nodes_per_face);
+} BMI_Model;
+
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/bmi.h
+++ b/bmi.h
@@ -14,70 +14,70 @@ extern "C" {
 #define BMI_MAX_VAR_NAME (2048)
 
 
-typedef struct BMI_Model {
+typedef struct Bmi {
   void *data;
 
   /* Initialize, run, finalize (IRF) */
-  int (*initialize)(struct BMI_Model *self, const char *config_file);
-  int (*update)(struct BMI_Model *self);
-  int (*update_until)(struct BMI_Model *self, double then);
-  int (*finalize)(struct BMI_Model *self);
+  int (*initialize)(struct Bmi *self, const char *config_file);
+  int (*update)(struct Bmi *self);
+  int (*update_until)(struct Bmi *self, double then);
+  int (*finalize)(struct Bmi *self);
 
   /* Exchange items */
-  int (*get_component_name)(struct BMI_Model *self, char *name);
-  int (*get_input_item_count)(struct BMI_Model *self, int *count);
-  int (*get_output_item_count)(struct BMI_Model *self, int *count);
-  int (*get_input_var_names)(struct BMI_Model *self, char **names);
-  int (*get_output_var_names)(struct BMI_Model *self, char **names);
+  int (*get_component_name)(struct Bmi *self, char *name);
+  int (*get_input_item_count)(struct Bmi *self, int *count);
+  int (*get_output_item_count)(struct Bmi *self, int *count);
+  int (*get_input_var_names)(struct Bmi *self, char **names);
+  int (*get_output_var_names)(struct Bmi *self, char **names);
 
   /* Variable information */
-  int (*get_var_grid)(struct BMI_Model *self, const char *name, int *grid);
-  int (*get_var_type)(struct BMI_Model *self, const char *name, char *type);
-  int (*get_var_units)(struct BMI_Model *self, const char *name, char *units);
-  int (*get_var_itemsize)(struct BMI_Model *self, const char *name, int *size);
-  int (*get_var_nbytes)(struct BMI_Model *self, const char *name, int *nbytes);
-  int (*get_var_location)(struct BMI_Model *self, const char *name, char *location);
+  int (*get_var_grid)(struct Bmi *self, const char *name, int *grid);
+  int (*get_var_type)(struct Bmi *self, const char *name, char *type);
+  int (*get_var_units)(struct Bmi *self, const char *name, char *units);
+  int (*get_var_itemsize)(struct Bmi *self, const char *name, int *size);
+  int (*get_var_nbytes)(struct Bmi *self, const char *name, int *nbytes);
+  int (*get_var_location)(struct Bmi *self, const char *name, char *location);
 
   /* Time information */
-  int (*get_current_time)(struct BMI_Model *self, double *time);
-  int (*get_start_time)(struct BMI_Model *self, double *time);
-  int (*get_end_time)(struct BMI_Model *self, double *time);
-  int (*get_time_units)(struct BMI_Model *self, char *units);
-  int (*get_time_step)(struct BMI_Model *self, double *time_step);
+  int (*get_current_time)(struct Bmi *self, double *time);
+  int (*get_start_time)(struct Bmi *self, double *time);
+  int (*get_end_time)(struct Bmi *self, double *time);
+  int (*get_time_units)(struct Bmi *self, char *units);
+  int (*get_time_step)(struct Bmi *self, double *time_step);
 
   /* Getters */
-  int (*get_value)(struct BMI_Model *self, const char *name, void *dest);
-  int (*get_value_ptr)(struct BMI_Model *self, const char *name, void **dest_ptr);
-  int (*get_value_at_indices)(struct BMI_Model *self, const char *name, void *dest, int *inds, int count);
+  int (*get_value)(struct Bmi *self, const char *name, void *dest);
+  int (*get_value_ptr)(struct Bmi *self, const char *name, void **dest_ptr);
+  int (*get_value_at_indices)(struct Bmi *self, const char *name, void *dest, int *inds, int count);
 
   /* Setters */
-  int (*set_value)(struct BMI_Model *self, const char *name, void *src);
-  int (*set_value_at_indices)(struct BMI_Model *self, const char *name, int *inds, int count, void *src);
+  int (*set_value)(struct Bmi *self, const char *name, void *src);
+  int (*set_value_at_indices)(struct Bmi *self, const char *name, int *inds, int count, void *src);
 
   /* Grid information */
-  int (*get_grid_rank)(struct BMI_Model *self, int grid, int *rank);
-  int (*get_grid_size)(struct BMI_Model *self, int grid, int *size);
-  int (*get_grid_type)(struct BMI_Model *self, int grid, char *type);
+  int (*get_grid_rank)(struct Bmi *self, int grid, int *rank);
+  int (*get_grid_size)(struct Bmi *self, int grid, int *size);
+  int (*get_grid_type)(struct Bmi *self, int grid, char *type);
 
   /* Uniform rectilinear */
-  int (*get_grid_shape)(struct BMI_Model *self, int grid, int *shape);
-  int (*get_grid_spacing)(struct BMI_Model *self, int grid, double *spacing);
-  int (*get_grid_origin)(struct BMI_Model *self, int grid, double *origin);
+  int (*get_grid_shape)(struct Bmi *self, int grid, int *shape);
+  int (*get_grid_spacing)(struct Bmi *self, int grid, double *spacing);
+  int (*get_grid_origin)(struct Bmi *self, int grid, double *origin);
 
   /* Non-uniform rectilinear, curvilinear */
-  int (*get_grid_x)(struct BMI_Model *self, int grid, double *x);
-  int (*get_grid_y)(struct BMI_Model *self, int grid, double *y);
-  int (*get_grid_z)(struct BMI_Model *self, int grid, double *z);
+  int (*get_grid_x)(struct Bmi *self, int grid, double *x);
+  int (*get_grid_y)(struct Bmi *self, int grid, double *y);
+  int (*get_grid_z)(struct Bmi *self, int grid, double *z);
 
   /* Unstructured */
-  int (*get_grid_node_count)(struct BMI_Model *self, int grid, int *count);
-  int (*get_grid_edge_count)(struct BMI_Model *self, int grid, int *count);
-  int (*get_grid_face_count)(struct BMI_Model *self, int grid, int *count);
-  int (*get_grid_edge_nodes)(struct BMI_Model *self, int grid, int *edge_nodes);
-  int (*get_grid_face_edges)(struct BMI_Model *self, int grid, int *face_edges);
-  int (*get_grid_face_nodes)(struct BMI_Model *self, int grid, int *face_nodes);
-  int (*get_grid_nodes_per_face)(struct BMI_Model *self, int grid, int *nodes_per_face);
-} BMI_Model;
+  int (*get_grid_node_count)(struct Bmi *self, int grid, int *count);
+  int (*get_grid_edge_count)(struct Bmi *self, int grid, int *count);
+  int (*get_grid_face_count)(struct Bmi *self, int grid, int *count);
+  int (*get_grid_edge_nodes)(struct Bmi *self, int grid, int *edge_nodes);
+  int (*get_grid_face_edges)(struct Bmi *self, int grid, int *face_edges);
+  int (*get_grid_face_nodes)(struct Bmi *self, int grid, int *face_nodes);
+  int (*get_grid_nodes_per_face)(struct Bmi *self, int grid, int *nodes_per_face);
+} Bmi;
 
 
 #if defined(__cplusplus)


### PR DESCRIPTION
This pull request updates *bmi.h* to pass pointers to a *Bmi* struct as a first argument.
```c
int (*initialize)(struct Bmi *self, const char *config_file);
```
That is, the first argument is a `struct Bmi *self` rather than `void *self`.

```c
Bmi * model = (Bmi*)malloc(sizeof(Bmi)); // Allocate memory for the BMI

register_bmi(model);  // Initialize the BMI methods and any model data

// Call the BMI methods
model->initialize(model, "config_file.txt");
model->update_until(model, 10.5);
model->finalize(model);
```

I've also wrapped the header with `extern "C"` for C++.