### PR TITLE
Update CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(bmic C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,18 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(bmic C)
+project(bmic LANGUAGES C)
 
 set(BMI_VERSION 2.0)
+include(GNUInstallDirs)
 
 configure_file(${CMAKE_SOURCE_DIR}/${CMAKE_PROJECT_NAME}.pc.cmake
   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.pc)
 
 install(
   FILES bmi.h
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(
   FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.pc
-  DESTINATION lib/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ into an Anaconda distribution with
 
 ### Linux and macOS
 
-To install the C BMI bindings from source with cmake, run
+To install the C BMI bindings from source with CMake, run
 
     mkdir _build && cd _build
     cmake .. -DCMAKE_INSTALL_PREFIX=<path-to-installation>
@@ -36,6 +36,8 @@ To install the C BMI bindings from source with cmake, run
 
 where `<path-to-installation>` is the base directory
 in which to install the bindings (`/usr/local` is the default).
+When using a conda environment,
+use the `$CONDA_PREFIX` environment variable.
 
 The installation will look like:
 
@@ -54,7 +56,7 @@ An additional prerequisite is needed for Windows:
 
 * Microsoft Visual Studio 2017 or Microsoft Build Tools for Visual Studio 2017
 
-To configure and install the C BMI bindings from source with cmake,
+To configure and install the C BMI bindings from source with CMake,
 run the following in a [Developer Command Prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
 
     mkdir _build && cd _build
@@ -64,10 +66,10 @@ run the following in a [Developer Command Prompt](https://docs.microsoft.com/en-
 	  -DCMAKE_BUILD_TYPE=Release
 	cmake --build . --target install --config Release
 
-where `<path-to-installation>` is the base directory
-in which to install the bindings (`"C:\Program Files (x86)"` is the default;
-note that quotes and an absolute path are needed).
-
+where `<path-to-installation>` is the base directory in which to install the bindings.
+The default is `"C:\Program Files (x86)"`.
+Note that quotes and an absolute path are needed.
+When using a conda environment, use `"%CONDA_PREFIX%\Library"`.
 
 ## Use
 

--- a/bmic.pc.cmake
+++ b/bmic.pc.cmake
@@ -1,5 +1,5 @@
 Name: Bmi
 Description: The Basic Model Interface
 Version: ${BMI_VERSION}
-Libs: -L${CMAKE_INSTALL_PREFIX}/lib -lbmic
-Cflags: -I${CMAKE_INSTALL_PREFIX}/include
+Libs: -L${CMAKE_INSTALL_LIBDIR} -lbmic
+Cflags: -I${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
This PR makes three minor changes to the CMake build process:

1. Inspired by @mwtoews in https://github.com/csdms/bmi-fortran/pull/47, use GnuInstallDirs and variables for standard install locations.
2. Update the minimum required CMake version to remove a deprecation warning.
3. Suggest where to install the specification when using a conda environment.