### PR TITLE
Use full path CMake variables

### DIFF
--- a/bmic.pc.cmake
+++ b/bmic.pc.cmake
@@ -2,5 +2,5 @@ Name: bmi-c
 Description: The Basic Model Interface for C
 URL: https://bmi.readthedocs.io
 Version: ${BMI_VERSION}
-Libs: -L${CMAKE_INSTALL_LIBDIR} -l${CMAKE_PROJECT_NAME}
-Cflags: -I${CMAKE_INSTALL_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -l${CMAKE_PROJECT_NAME}
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}


### PR DESCRIPTION
This PR changes the template pkg-config file to use the `CMAKE_INSTALL_FULL_<dir>` variables instead of the `CMAKE_INSTALL_<dir>` variables used in the build process.

This fixes #9.